### PR TITLE
chore: bump `CustomCode.Analyzer` from 0.2.0 to 0.2.1

### DIFF
--- a/AGV.ZXing/AGV.ZXing.csproj
+++ b/AGV.ZXing/AGV.ZXing.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CustomCode.Analyzer" Version="0.2.0">
+    <PackageReference Include="CustomCode.Analyzer" Version="0.2.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Hi André, this release fixes the three issues you reported:

* https://github.com/jonathanalgar/CustomCode-Analyzer/issues/26
* https://github.com/jonathanalgar/CustomCode-Analyzer/issues/28
* https://github.com/jonathanalgar/CustomCode-Analyzer/issues/30

So now the project now gives a clean:

```
> dotnet build
Restore complete (0.6s)
  AGV.ZXing succeeded with 1 warning(s) (5.7s) → bin\Debug\net8.0\AGV.ZXing.dll
    C:\Users\nhg\AGV.ZXING\AGV.ZXing\IZXing.cs(17,13): warning InputSizeLimit: One or more methods accept binary data. Note that external libraries have a 5.5MB total input size limit. For large files, use a REST API endpoint or file URL instead. (https://success.outsystems.com/documentation/outsystems_developer_cloud/building_apps/extend_your_apps_with_custom_code/external_libraries_sdk_readme/#use-with-large-binary-files)

Build succeeded with 1 warning(s) in 7.1s
```

Thanks again!